### PR TITLE
Batch Dialog - Overrides

### DIFF
--- a/loom.py
+++ b/loom.py
@@ -1675,6 +1675,7 @@ class LOOM_MT_display_settings(bpy.types.Menu):
 class LOOM_UL_batch_list(bpy.types.UIList):
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
         prefs = context.preferences.addons[__name__].preferences
+        file_exists = os.path.isfile(item.path)
         lum = context.scene.loom
 
         if prefs.batch_paths_flag:
@@ -1690,7 +1691,7 @@ class LOOM_UL_batch_list(bpy.types.UIList):
                 text="{:02d}".format(index+1), 
                 emboss=False).item_id = index
             split_left.label(text=item.name, icon='FILE_BLEND')
-            
+        
         split_right = split.split(factor=.99)
         row = split_right.row(align=True)        
         row.operator(
@@ -1704,8 +1705,8 @@ class LOOM_UL_batch_list(bpy.types.UIList):
             LOOM_OT_batch_verify_input.bl_idname, 
             text="", 
             icon='GHOST_ENABLED').item_id = index
-        
-        if lum.override_batch_render_settings:
+
+        if lum.override_batch_render_settings and file_exists:
 
             row.separator(factor=1)
             #row.label(text="", icon='FILE_IMAGE')
@@ -1720,8 +1721,12 @@ class LOOM_UL_batch_list(bpy.types.UIList):
 
         row.prop(item, "encode_flag", text="", icon='RENDER_ANIMATION')
         row.separator(factor=1)
+        folder_icon = "DISK_DRIVE" if file_exists else 'ERROR'
         row.operator(LOOM_OT_open_folder.bl_idname, 
-                icon="DISK_DRIVE", text="").folder_path = os.path.dirname(item.path)
+            icon=folder_icon, text="").folder_path = os.path.dirname(item.path)
+
+        if not file_exists:
+            layout.enabled = False
 
     def invoke(self, context, event):
         pass

--- a/loom.py
+++ b/loom.py
@@ -407,7 +407,7 @@ class LOOM_AP_preferences(bpy.types.AddonPreferences):
         name="Batch Dialog Width",
         description="Width of Batch Render Dialog",
         subtype='PIXEL',
-        default=750, min=600, max=1800)
+        default=800, min=600, max=1800)
 
     batch_dialog_rows: bpy.props.IntProperty(
         name="Number of Rows",

--- a/loom.py
+++ b/loom.py
@@ -1659,7 +1659,7 @@ class LOOM_MT_display_settings(bpy.types.Menu):
     def draw(self, context):
         prefs = context.preferences.addons[__name__].preferences
         layout = self.layout
-        layout.label(text="Display Settings", icon="COLOR")
+        layout.label(text="Display Settings", icon="DESKTOP") #COLOR
         layout.separator()
         if context.scene.loom.override_batch_render_settings:
             layout.prop(prefs, "batch_icon_only_flag")
@@ -1955,7 +1955,7 @@ class LOOM_OT_batch_dialog(bpy.types.Operator):
         col = row.column(align=True)
         #settings_icon = 'MODIFIER_OFF' if lum.override_batch_render_settings else 'MODIFIER_ON'
         col.prop(lum, "override_batch_render_settings", text="", icon='MODIFIER_ON') # TOOL_SETTINGS
-        col.menu(LOOM_MT_display_settings.bl_idname, icon="COLOR", text="") #, icon='DOWNARROW_HLT',
+        col.menu(LOOM_MT_display_settings.bl_idname, icon="DOWNARROW_HLT", text="") # COLOR,
 
         col.separator(factor=3)
         col.operator(LOOM_OT_batch_selected_blends.bl_idname, icon='ADD', text="")

--- a/loom.py
+++ b/loom.py
@@ -2184,7 +2184,9 @@ class LOOM_OT_batch_snapshot(bpy.types.Operator):
         row = layout.row(align=True)
         if self.globals_flag:
             row.prop(self, "apply_globals", toggle=True)
-        row.prop(self, "convert_paths", toggle=True)
+        
+        row = layout.row(align=True)
+        row.prop(self, "convert_paths")
         '''
         col = layout.column(align=True)
         row = col.row(align=True)
@@ -2193,7 +2195,7 @@ class LOOM_OT_batch_snapshot(bpy.types.Operator):
             row = col.row(align=True)
             row.prop(self, "apply_globals", toggle=True)
         '''
-        layout.row()
+        layout.separator(factor=.2)
 
 
 class LOOM_OT_batch_selected_blends(bpy.types.Operator, ImportHelper):

--- a/loom.py
+++ b/loom.py
@@ -784,7 +784,7 @@ class LOOM_PG_render(bpy.types.PropertyGroup):
 
 
 def render_preset_callback(self, context):
-    items = [('EMPTY', "Current Render Settings", "")]
+    items = [('EMPTY', "Active Render Settings", "")]
     preset_path = context.preferences.addons[__name__].preferences.render_presets_path
     if os.path.exists(preset_path):
         for f in os.listdir(preset_path):
@@ -795,7 +795,7 @@ def render_preset_callback(self, context):
     return items
 
 def render_scene_callback(self, context):
-    items = [('NONE', "Current Scene", "")]
+    items = [('NONE', "Active Scene", "")]
     if os.path.exists(self.path) and context.scene.loom.override_batch_render_settings:
         scene_list = None
         with bpy.data.libraries.load(self.path) as (data_from, data_to):

--- a/loom.py
+++ b/loom.py
@@ -1684,20 +1684,20 @@ class LOOM_UL_batch_list(bpy.types.UIList):
         row.prop(item, "frames", text="") #, icon='IMAGEFILE'
         #row = split_right.row(align=True) #row.prop(item, "input_filter", text="", icon='FILTER')
         row.prop(item, "input_filter", text="", icon='FILTER')
-
-        row.prop(item, "encode_flag", text="", icon='FILE_MOVIE')
         row.operator(
             LOOM_OT_batch_verify_input.bl_idname, 
             text="", 
             icon='GHOST_ENABLED').item_id = index
-        row.separator()
-        row.prop(item, "scene_override", text="", icon='SCENE_DATA')
+        
+        row.separator(factor=2)
+        row.prop(item, "scene_override", text="", icon='FILE_IMAGE')
         if item.scene_override:
             row.prop(item, "scene_selection", text="")
         row.prop(item, "camera_override", text="", icon='CAMERA_DATA')
         if item.camera_override:
             row.prop(item, "camera_selection", text="")
-        row.separator()
+        row.prop(item, "encode_flag", text="", icon='RENDER_ANIMATION')
+        row.separator(factor=1)
         row.operator(LOOM_OT_open_folder.bl_idname, 
                 icon="DISK_DRIVE", text="").folder_path = os.path.dirname(item.path)
 


### PR DESCRIPTION
This patch basically allows to override the render settings per item (scene, camera and render template) in the render queue and keeps the UI compact and clean.

![ezgif-7-9a9290f9b7](https://github.com/user-attachments/assets/8e98cabd-d505-4bde-8afe-1ce6d696fd6d)
