### PR TITLE
Globals support for custom render notes (metadata)

### DIFF
--- a/loom.py
+++ b/loom.py
@@ -5193,7 +5193,7 @@ def loom_meta_note(scene):
         if len(lines) > 1:
             scene.render.stamp_note_text += os.linesep
             for i in lines[1:]:
-                scene.render.stamp_note_text += i.lstrip(" ") + os.linesep
+                scene.render.stamp_note_text += i + os.linesep
 
 @persistent
 def loom_meta_note_reset(scene):

--- a/loom.py
+++ b/loom.py
@@ -5887,7 +5887,7 @@ def draw_loom_outputpath(self, context):
     if globals_flag or context.scene.loom.path_collection:
         if len(original_paths) and not original_paths[0].orig == context.scene.render.filepath:
             sub_row.operator(LOOM_OT_bake_globals.bl_idname, icon="RECOVER_LAST", text="").action='RESET'
-        sub_row.operator(LOOM_OT_bake_globals.bl_idname, icon="MESH_UVSPHERE", text="").action='APPLY' #WORLD_DATA
+        sub_row.operator(LOOM_OT_bake_globals.bl_idname, icon="WORLD_DATA", text="").action='APPLY' #WORLD_DATA
         #sub_row.operator_enum(LOOM_OT_bake_globals.bl_idname, "action", icon_only=True)
 
     sub_row.operator(LOOM_OT_output_paths.bl_idname, icon="EXTERNAL_DRIVE", text="") #NETWORK_DRIVE

--- a/loom.py
+++ b/loom.py
@@ -5887,7 +5887,7 @@ def draw_loom_outputpath(self, context):
     if globals_flag or context.scene.loom.path_collection:
         if len(original_paths) and not original_paths[0].orig == context.scene.render.filepath:
             sub_row.operator(LOOM_OT_bake_globals.bl_idname, icon="RECOVER_LAST", text="").action='RESET'
-        sub_row.operator(LOOM_OT_bake_globals.bl_idname, icon="WORLD_DATA", text="").action='APPLY' #WORLD_DATA
+        sub_row.operator(LOOM_OT_bake_globals.bl_idname, icon="WORLD_DATA", text="").action='APPLY'
         #sub_row.operator_enum(LOOM_OT_bake_globals.bl_idname, "action", icon_only=True)
 
     sub_row.operator(LOOM_OT_output_paths.bl_idname, icon="EXTERNAL_DRIVE", text="") #NETWORK_DRIVE

--- a/loom.py
+++ b/loom.py
@@ -5189,11 +5189,11 @@ def loom_meta_note(scene):
             scene.render.stamp_note_text = replace_globals(scene.render.stamp_note_text)
         
         lines = scene.render.stamp_note_text.split("\\n")
-        scene.render.stamp_note_text = lines[0].strip(" ")
+        scene.render.stamp_note_text = lines[0]
         if len(lines) > 1:
             scene.render.stamp_note_text += os.linesep
             for i in lines[1:]:
-                scene.render.stamp_note_text += i.strip(" ") + os.linesep
+                scene.render.stamp_note_text += i.lstrip(" ") + os.linesep
 
 @persistent
 def loom_meta_note_reset(scene):

--- a/loom.py
+++ b/loom.py
@@ -5385,7 +5385,9 @@ def draw_loom_metadata(self, context):
     if globals_flag or "\\n" in note_text:
         layout = self.layout
         box = layout.box()
-        box.row().label(text=note_text.replace("\\n", " ¶ "), icon="MESH_UVSPHERE")
+        row = box.row()
+        row.label(text=" " + note_text.replace("\\n", " ¶ "))
+        row.label(text="", icon="MESH_UVSPHERE")
         """
         lines = note_text.split("\\n")
         layout.row().label(text="Globals", icon="WORLD") # lines[0]

--- a/loom.py
+++ b/loom.py
@@ -5373,7 +5373,7 @@ def draw_loom_metadata(self, context):
     glob_vars = prefs.global_variable_coll
     scn = context.scene
 
-    if not scn.render.use_stamp_note or scn.render.is_movie_format:
+    if not scn.render.use_stamp_note: #or scn.render.is_movie_format:
         return
     
     globals_flag = False
@@ -5386,8 +5386,14 @@ def draw_loom_metadata(self, context):
         layout = self.layout
         box = layout.box()
         row = box.row()
-        row.label(text=" " + note_text.replace("\\n", " ¶ "))
-        row.label(text="", icon="MESH_UVSPHERE")
+        txt = " " + note_text.replace("\\n", " ¶ ")
+        icn = 'MESH_UVSPHERE'
+        if scn.render.is_movie_format:
+            txt = " Video file formats are not supported by Loom"
+            icn = 'ERROR'
+        row.label(text=txt)
+        row.label(text="", icon=icn)
+
         """
         lines = note_text.split("\\n")
         layout.row().label(text="Globals", icon="WORLD") # lines[0]

--- a/loom.py
+++ b/loom.py
@@ -5968,7 +5968,7 @@ def draw_loom_metadata(self, context):
                 layout.row().label(text="" + i, icon="DOT" ) #¶ FONTPREVIEW
             layout.separator(factor=0.3)
         """
-        layout.separator(factor=0.3)
+        #layout.separator(factor=0.3)
 
 
 def draw_loom_project(self, context):
@@ -6247,7 +6247,7 @@ def register():
     bpy.types.RENDER_PT_output.prepend(draw_loom_outputpath)
     bpy.types.RENDER_PT_output.append(draw_loom_version_number)
     bpy.types.RENDER_PT_output.append(draw_loom_compositor_paths)
-    bpy.types.RENDER_PT_stamp_note.append(draw_loom_metadata)
+    bpy.types.RENDER_PT_stamp_note.prepend(draw_loom_metadata)
     bpy.types.DOPESHEET_HT_header.append(draw_loom_dopesheet)
     bpy.types.PROPERTIES_HT_header.append(draw_loom_render_presets)
     bpy.types.LOOM_PT_render_presets.append(draw_loom_preset_flags) 


### PR DESCRIPTION
This patch allows to use predefined globals like `$CAMERA`, `$LENS` or `$F4` within the _Note_ field of the _Metadata Panel_ (#86).

**Samples**

- `Render Camera:     $CAMERA\nCurrent Frame:     $F4\nFocal Length:      $LENS`
- `Render Camera:     $CAMERA\nCurrent Frame:     $F4\n Focal Length:     $LENS`
- `Render Camera:     $CAMERA\nCurrent Frame:     $F4\nFocale:            $LENS`
- `Render Camera:     $CAMERA\nCurrent Frame:     $F4\n       Focale:     $LENS`

**Result**

<img width="699" alt="Screenshot 2024-01-25 at 08 25 53" src="https://github.com/p2or/blender-loom/assets/512368/d1acadee-e568-4a7a-8300-1dfd6552e6e9">

<img width="699" alt="Screenshot 2024-01-25 at 08 44 34" src="https://github.com/p2or/blender-loom/assets/512368/12d9aa5d-efa9-4be4-af47-ba9b76eb7f0c">
