### PR TITLE
Fix crash when accessing sequence_editor.sequences on scenes without VSE

### DIFF
--- a/loom.py
+++ b/loom.py
@@ -3986,13 +3986,12 @@ class LOOM_OT_render_image_sequence(bpy.types.Operator):
         if self.validate_scene:
             if scn.render.use_sequencer and hasattr(scn.sequence_editor, "sequences"):  
                 if len(scn.sequence_editor.sequences) and self.validate_sequencer(context): 
-                    if self.validate_sequencer(context):
-                        if len(self._frames) > 1 and not self.render_silent:
-                            self.report(
-                                {'INFO'}, 
-                                "Scene Strip(s) in 'Sequencer' detected: " 
-                                "Automatically switched to 'silent' rendering...")
-                            self.render_silent = True
+                    if len(self._frames) > 1 and not self.render_silent:
+                        self.report(
+                            {'INFO'}, 
+                            "Scene Strip(s) in 'Sequencer' detected: " 
+                            "Automatically switched to 'silent' rendering...")
+                        self.render_silent = True
             else:
                 if scn.render.use_compositing and scn.use_nodes:
                     rlyr = self.validate_comp(context)

--- a/loom.py
+++ b/loom.py
@@ -1232,8 +1232,8 @@ class LOOM_OT_render_dialog(bpy.types.Operator):
             user_error = True
         
         """ Scene validation """
-        if scn.render.use_sequencer and hasattr(scn, "sequencer"):
-            if scn.sequence_editor and len(scn.sequence_editor.sequences) and self.validate_sequencer(context):
+        if scn.render.use_sequencer and hasattr(scn.sequence_editor, "sequences"):  
+            if len(scn.sequence_editor.sequences) and self.validate_sequencer(context): 
                 if not user_input.isdigit():
                     self.report(
                         {'INFO'}, 
@@ -3984,14 +3984,15 @@ class LOOM_OT_render_image_sequence(bpy.types.Operator):
 
         """ Scene validation in case the operator is called via console """
         if self.validate_scene:
-            if scn.sequence_editor and scn.render.use_sequencer and len(scn.sequence_editor.sequences):
-                if self.validate_sequencer(context):
-                    if len(self._frames) > 1 and not self.render_silent:
-                        self.report(
-                            {'INFO'}, 
-                            "Scene Strip(s) in 'Sequencer' detected: " 
-                            "Automatically switched to 'silent' rendering...")
-                        self.render_silent = True
+            if scn.render.use_sequencer and hasattr(scn.sequence_editor, "sequences"):  
+                if len(scn.sequence_editor.sequences) and self.validate_sequencer(context): 
+                    if self.validate_sequencer(context):
+                        if len(self._frames) > 1 and not self.render_silent:
+                            self.report(
+                                {'INFO'}, 
+                                "Scene Strip(s) in 'Sequencer' detected: " 
+                                "Automatically switched to 'silent' rendering...")
+                            self.render_silent = True
             else:
                 if scn.render.use_compositing and scn.use_nodes:
                     rlyr = self.validate_comp(context)

--- a/loom.py
+++ b/loom.py
@@ -1233,7 +1233,7 @@ class LOOM_OT_render_dialog(bpy.types.Operator):
         
         """ Scene validation """
         if scn.render.use_sequencer and hasattr(scn, "sequencer"):
-            if len(scn.sequence_editor.sequences) and self.validate_sequencer(context):
+            if scn.sequence_editor and len(scn.sequence_editor.sequences) and self.validate_sequencer(context):
                 if not user_input.isdigit():
                     self.report(
                         {'INFO'}, 
@@ -3984,7 +3984,7 @@ class LOOM_OT_render_image_sequence(bpy.types.Operator):
 
         """ Scene validation in case the operator is called via console """
         if self.validate_scene:
-            if scn.render.use_sequencer and len(scn.sequence_editor.sequences):
+            if scn.sequence_editor and scn.render.use_sequencer and len(scn.sequence_editor.sequences):
                 if self.validate_sequencer(context):
                     if len(self._frames) > 1 and not self.render_silent:
                         self.report(


### PR DESCRIPTION
new scene doesn't have `scn.sequence_editor`, so an error occurs at `len(scn.sequence_editor.sequences)`

![image](https://github.com/user-attachments/assets/8e4258d1-e77b-4c02-bf9c-729e8563b221)
